### PR TITLE
KMS encryption keys

### DIFF
--- a/terraform/.terraform/development.tfvars
+++ b/terraform/.terraform/development.tfvars
@@ -1,2 +1,3 @@
 aws_region="us-east-1"
+aws_replication_region="us-west-2"
 environment="dev"

--- a/terraform/.terraform/production.tfvars
+++ b/terraform/.terraform/production.tfvars
@@ -1,2 +1,3 @@
 aws_region="us-east-1"
+aws_replication_region="us-west-2"
 environment="prod"

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -1,0 +1,27 @@
+resource "aws_kms_key" "primary" {
+  description         = "A custom, multi-region encryption key for securing data globally"
+  enable_key_rotation = true
+  multi_region        = true
+}
+
+resource "aws_kms_alias" "primary" {
+  name = "alias/${local.namespace}"
+  target_key_id = aws_kms_key.primary.key_id
+}
+
+# Replicated KMS key
+#
+# TODO: support taking a list of replicated regions?
+resource "aws_kms_replica_key" "replicated" {
+  provider = aws.replicated
+
+  description     = "Multi-region replica key"
+  primary_key_arn = aws_kms_key.primary.arn
+}
+
+resource "aws_kms_alias" "replicated" {
+  provider = aws.replicated
+
+  name = "alias/${local.namespace}"
+  target_key_id = aws_kms_replica_key.replicated.key_id
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  default_tags = {
+    Application = "aws-swan-demo"
+    Environment = var.environment
+  }
+  namespace = "aws-swan-demo-${var.environment}"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,13 +13,18 @@ terraform {
 
 provider "aws" {
   default_tags {
-    tags = {
-      Application = "aws-swan-demo"
-      Environment = var.environment
-    }
+    tags = local.default_tags
   }
 
   region = var.aws_region
 }
 
-resource "aws_s3_bucket" "test" {}
+provider "aws" {
+  alias = "replicated"
+
+  default_tags {
+    tags = local.default_tags
+  }
+
+  region = var.aws_replication_region
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_replication_region" {
+  default     = "us-west-2"
+  description = "The AWS replication region where resources are provisioned for failover"
+  type        = string
+}
+
 variable "environment" {
   description = "Name of the provisioned environment for namespacing purposes"
   type = string


### PR DESCRIPTION
Addresses #5 by implementing an additional AWS provisioner in Terraform and defining a multi-region, primary KMS key with the default provisioner and an additional replica key using the `replicated` provisioner, whose region can be set via a variable. Automatic key rotation is enabled.