### PR TITLE
CloudWatch log group encryption using KMS CMK

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,11 +1,8 @@
+# Encrypt log data with KMS CMK: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
 resource "aws_cloudwatch_log_group" "hello_world" {
-  # TODO: add KMS policy to key and associate for encryption:
-  #  https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
   kms_key_id        = aws_kms_key.primary.arn
   name              = "/ecs/${local.namespace}/hello-world"
   retention_in_days = 30
-
-  depends_on = [aws_kms_key.primary]
 }
 
 resource "aws_ecs_cluster" "cluster" {

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,9 +1,11 @@
 resource "aws_cloudwatch_log_group" "hello_world" {
   # TODO: add KMS policy to key and associate for encryption:
   #  https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
-  # kms_key_id = aws_kms_key.primary.arn
+  kms_key_id = aws_kms_key.primary.arn
   name              = "/ecs/${local.namespace}/hello-world"
   retention_in_days = 30
+
+  depends_on = [aws_kms_key.primary]
 }
 
 resource "aws_ecs_cluster" "cluster" {

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_group" "hello_world" {
   # TODO: add KMS policy to key and associate for encryption:
   #  https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
-  kms_key_id = aws_kms_key.primary.arn
+  kms_key_id        = aws_kms_key.primary.arn
   name              = "/ecs/${local.namespace}/hello-world"
   retention_in_days = 30
 

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "kms_primary_default" {
       type        = "AWS"
     }
     resources = ["*"]
-    sid = "Enable IAM User Permissions"
+    sid       = "Enable IAM User Permissions"
   }
 
   # Grant access to encrypt the hello-world CloudWatch log group
@@ -27,13 +27,13 @@ data "aws_iam_policy_document" "kms_primary_default" {
     effect = "Allow"
     principals {
       identifiers = ["logs.${var.aws_region}.amazonaws.com"]
-      type = "Service"
+      type        = "Service"
     }
     resources = ["*"]
     condition {
       test = "ArnEquals"
       # Interpolate this (for now) due to dependency cycle when referencing
-      values = ["arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/ecs/aws-swan-demo-local/hello-world"]
+      values   = ["arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/ecs/aws-swan-demo-local/hello-world"]
       variable = "kms:EncryptionContext:aws:logs:arn"
     }
   }

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "kms_primary_default" {
     condition {
       test = "ArnEquals"
       # Interpolate this (for now) due to dependency cycle when referencing
-      values   = ["arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/ecs/aws-swan-demo-local/hello-world"]
+      values   = ["arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/ecs/${local.namespace}/hello-world"]
       variable = "kms:EncryptionContext:aws:logs:arn"
     }
   }

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -1,7 +1,49 @@
+data "aws_iam_policy_document" "kms_primary_default" {
+  policy_id = "key-default-1"
+
+  # This statement is a copy of the default statement,
+  #  so as to not lose access to the key.
+  statement {
+    actions = ["kms:*"]
+    effect  = "Allow"
+    principals {
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+      type        = "AWS"
+    }
+    resources = ["*"]
+    sid = "Enable IAM User Permissions"
+  }
+
+  # Grant access to encrypt the hello-world CloudWatch log group
+  #  https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
+  statement {
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    effect = "Allow"
+    principals {
+      identifiers = ["logs.${var.aws_region}.amazonaws.com"]
+      type = "Service"
+    }
+    resources = ["*"]
+    condition {
+      test = "ArnEquals"
+      # Interpolate this (for now) due to dependency cycle when referencing
+      values = ["arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/ecs/aws-swan-demo-local/hello-world"]
+      variable = "kms:EncryptionContext:aws:logs:arn"
+    }
+  }
+}
+
 resource "aws_kms_key" "primary" {
   description         = "A custom, multi-region encryption key for securing data globally"
   enable_key_rotation = true
   multi_region        = true
+  policy              = data.aws_iam_policy_document.kms_primary_default.json
 }
 
 resource "aws_kms_alias" "primary" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  account_id = data.aws_caller_identity.current.account_id
   alb_ips = [for v in aws_lb.alb.subnet_mapping : v.private_ipv4_address]
   default_tags = {
     Application = "aws-swan-demo"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,6 +1,6 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
-  alb_ips = [for v in aws_lb.alb.subnet_mapping : v.private_ipv4_address]
+  alb_ips    = [for v in aws_lb.alb.subnet_mapping : v.private_ipv4_address]
   default_tags = {
     Application = "aws-swan-demo"
     Environment = var.environment


### PR DESCRIPTION
This PR includes a KMS CMK key policy granting access to the `hello-world` ECS task log group for the primary key using a context. The original policy is preserved so as to not lose access to the key, and the new policy statement is appended.

This resolves the final requirement for #8 