### PR TITLE
DNS and HTTPS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,10 @@ on:
         description: The key of the Terraform .tfstate file in AWS S3
         required: true
         type: string
+      dns_name:
+        description: The DNS name to be configured as a Route53 hosted zone
+        required: true
+        type: string
       environment_name:
         description: The name of the environment configured in Github repository settings
         required: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,5 +62,6 @@ jobs:
           terraform apply -auto-approve \
             -var="aws_region=${{ inputs.aws_region }}" \
             -var="aws_replication_region=${{ inputs.aws_replication_region }}" \
+            -var="dns_name=${{ inputs.dns_name }}" \
             -var="environment=${{ inputs.environment_name }}"
         working-directory: ./terraform

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -27,7 +27,7 @@ jobs:
       aws_region: us-east-1
       aws_replication_region: us-west-2
       aws_s3_terraform_state_object_key: development.tfstate
-      dns_name: aws-ecs-demo.dev.carlucci.network
+      dns_name: dev.aws-ecs-demo.carlucci.network
       environment_name: dev
     secrets:
       aws_assume_role_arn: ${{ secrets.AWS_ASSUME_ROLE_ARN }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -27,6 +27,7 @@ jobs:
       aws_region: us-east-1
       aws_replication_region: us-west-2
       aws_s3_terraform_state_object_key: development.tfstate
+      dns_name: aws-ecs-demo.dev.carlucci.network
       environment_name: dev
     secrets:
       aws_assume_role_arn: ${{ secrets.AWS_ASSUME_ROLE_ARN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,6 +26,7 @@ jobs:
       aws_region: us-east-1
       aws_replication_region: us-west-2
       aws_s3_terraform_state_object_key: production.tfstate
+      dns_name: aws-ecs-demo.prod.carlucci.network
       environment_name: prod
     secrets:
       aws_assume_role_arn: ${{ secrets.AWS_ASSUME_ROLE_ARN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* SSL traffic encryption terminating at the ALB
+* DNS resolution
 * Update README
 * Add ALB DNS name as a Terraform output
 * Parameterize ECS CPU and memory

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A demo application featuring deployment and CI/CD for a Hello World application 
 ## Environments
 
 * Production: https://aws-ecs-demo.carlucci.network
-* Development: https://aws-ecs-demo.dev.carlucci.network
+* Development: https://dev.aws-ecs-demo.carlucci.network
 
 Route53 hosted zones are provisioned for each environment and DNS name servers are delegated to from the parent domain.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A demo application featuring deployment and CI/CD for a Hello World application on AWS ECS Fargate. Infrastructure is defined in Terraform code and deployed automatically.
 
+## Environments
+
+* Production: https://aws-ecs-demo.carlucci.network
+* Development: https://aws-ecs-demo.dev.carlucci.network
+
+Route53 hosted zones are provisioned for each environment and DNS name servers are delegated to from the parent domain.
+
 ## Features
 
 * Repository build process and CI/CD with Github Actions using an OIDC integration with AWS

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A demo application featuring deployment and CI/CD for a Hello World application 
 * An application load balancer receiving public traffic and forwarding to ECS in private subnets
 * Definition of a KMS customer managed key for encryption, with support for cross-region replication to enable future multi-region deployments
 * CloudWatch logging with KMS CMK encryption
+* DNS name resolution
+* SSL traffic encryption terminating at the ALB
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ Generally, pull requests that contain a more-or-less complete feature implementa
 [CHANGELOG.md](CHANGELOG.md) keeps a record of the features in each release and new work should be documented in the "Unreleased" section until the next release.
 
 Whenever we get around to customizing the Docker image into a more complicated application, we will be using the [3musketeers](https://github.com/flemay/3musketeers) pattern to standardize an interface for common development tasks and processes.
+
+## Alternatives
+
+### AWS Copilot
+
+It is worth noting that the majority of this infrastructure could be quickly and easily configured and deployed using [AWS Copilot](https://aws.github.io/copilot-cli).
+
+### Contributed Terraform modules
+
+There is a large online library of contributed Terraform modules that could be leveraged to speed the development process. However, we generally prefer to write the Terraform code custom. One never knows how restricted access is to the underlying infrastructure resources until later in the application lifecycle. Decoupling from contributed infrastructure dependencies can be tricky and time consuming.

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,5 +1,5 @@
 resource "aws_acm_certificate" "cert" {
-  domain_name = aws_route53_zone.primary.name
+  domain_name       = aws_route53_zone.primary.name
   validation_method = "DNS"
 }
 

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,0 +1,9 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name = aws_route53_zone.primary.name
+  validation_method = "DNS"
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
+}

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,6 +1,10 @@
 resource "aws_acm_certificate" "cert" {
   domain_name       = aws_route53_zone.primary.name
   validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_acm_certificate_validation" "cert" {

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -86,7 +86,7 @@ resource "aws_lb_listener" "alb" {
 }
 
 resource "aws_lb_listener" "https" {
-  certificate_arn = aws_acm_certificate.cert.arn
+  certificate_arn = aws_acm_certificate_validation.cert.certificate_arn
   default_action {
     target_group_arn = aws_lb_target_group.alb.id
     type             = "forward"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -77,7 +77,7 @@ resource "aws_lb_listener" "alb" {
       protocol    = "HTTPS"
       status_code = "HTTP_301"
     }
-    type     = "redirect"
+    type = "redirect"
   }
 
   load_balancer_arn = aws_lb.alb.id
@@ -86,7 +86,7 @@ resource "aws_lb_listener" "alb" {
 }
 
 resource "aws_lb_listener" "https" {
-  certificate_arn   = aws_acm_certificate.cert.arn
+  certificate_arn = aws_acm_certificate.cert.arn
   default_action {
     target_group_arn = aws_lb_target_group.alb.id
     type             = "forward"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,3 +2,8 @@ output "alb_dns_name" {
   description = "The application load balancer DNS name."
   value       = aws_lb.alb.dns_name
 }
+
+output "dns_name" {
+  description = "The DNS name of the application."
+  value       = var.dns_name
+}

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -2,7 +2,7 @@ resource "aws_route53_zone" "primary" {
   name = var.dns_name
 }
 
-resource "aws_route53_record" "alb" {
+resource "aws_route53_record" "alb_primary" {
   alias {
     evaluate_target_health = true
     name                   = aws_lb.alb.dns_name

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -5,12 +5,12 @@ resource "aws_route53_zone" "primary" {
 resource "aws_route53_record" "alb" {
   alias {
     evaluate_target_health = true
-    name = aws_lb.alb.dns_name
-    zone_id = aws_lb.alb.zone_id
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
   }
 
-  name = var.dns_name
-  type = "A"
+  name    = var.dns_name
+  type    = "A"
   zone_id = aws_route53_zone.primary.zone_id
 }
 

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -3,13 +3,30 @@ resource "aws_route53_zone" "primary" {
 }
 
 resource "aws_route53_record" "alb" {
-  zone_id = aws_route53_zone.primary.zone_id
-  name = var.dns_name
-  type = "A"
-
   alias {
     evaluate_target_health = true
     name = aws_lb.alb.dns_name
     zone_id = aws_lb.alb.zone_id
   }
+
+  name = var.dns_name
+  type = "A"
+  zone_id = aws_route53_zone.primary.zone_id
+}
+
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.primary.zone_id
 }

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,15 @@
+resource "aws_route53_zone" "primary" {
+  name = var.dns_name
+}
+
+resource "aws_route53_record" "alb" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name = var.dns_name
+  type = "A"
+
+  alias {
+    evaluate_target_health = true
+    name = aws_lb.alb.dns_name
+    zone_id = aws_lb.alb.zone_id
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,6 +16,11 @@ variable "cpu" {
   type        = number
 }
 
+variable "dns_name" {
+  description = "The public-facing DNS name for the application."
+  type        = string
+}
+
 variable "memory" {
   default     = 512
   description = "The memory resources allocated to the ECS service."


### PR DESCRIPTION
This PR enable DNS support and SSL traffic encryption terminating at the ALB, as described in #17. 

Features:
* Environment manifest DNS configuration
* Add DNS name as a Terraform output value
* Implement ACM certificate for the Route53 domain name with automatic DNS record validation
* Implement ALB HTTPS listener with associated ACM certificate
* Modify ALB HTTP listener to redirect to HTTPS
* Security group rule allowing HTTPS traffic to the ALB
* Route53 hosted zone and A record aliased to ALB
* `dns_name` Terraform variable