### PR TITLE
Additional ACM certificate assignment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,13 @@
 on:
   workflow_call:
     inputs:
+      additional_certificate_arns:
+        # Arrays are not supported by Github resuable workflow inputs. It might be best to
+        #  move back to defining each environment workflow completely independently.
+        default: "[]"
+        description: "A set of additional ACM certificate ARNs to be assigned to the ALB listener."
+        required: false
+        type: string
       aws_region:
         description: The AWS region target for deployment
         required: true
@@ -64,6 +71,7 @@ jobs:
       - name: Terraform Apply
         run: |
           terraform apply -auto-approve \
+            -var="additional_certificate_arns=${{ inputs.aws_region }}" \
             -var="aws_region=${{ inputs.aws_region }}" \
             -var="aws_replication_region=${{ inputs.aws_replication_region }}" \
             -var="dns_name=${{ inputs.dns_name }}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Terraform Apply
         run: |
           terraform apply -auto-approve \
-            -var="additional_certificate_arns=${{ inputs.aws_region }}" \
+            -var="additional_certificate_arns=${{ inputs.additional_certificate_arns }}" \
             -var="aws_region=${{ inputs.aws_region }}" \
             -var="aws_replication_region=${{ inputs.aws_replication_region }}" \
             -var="dns_name=${{ inputs.dns_name }}" \

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,7 +26,7 @@ jobs:
       aws_region: us-east-1
       aws_replication_region: us-west-2
       aws_s3_terraform_state_object_key: production.tfstate
-      dns_name: aws-ecs-demo.carlucci.network
+      dns_name: prod.aws-ecs-demo.carlucci.network
       environment_name: prod
       vpc_cidr_index: 0
     secrets:

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -96,3 +96,11 @@ resource "aws_lb_listener" "https" {
   port              = 443
   protocol          = "HTTPS"
 }
+
+# Support the assigment of external certificates by ARN
+resource "aws_lb_listener_certificate" "additional" {
+  for_each = var.additional_certificate_arns
+
+  listener_arn    = aws_lb_listener.https.arn
+  certificate_arn = each.value
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,9 @@
+variable "additional_certificate_arns" {
+  default     = []
+  description = "A set of additional ACM certificate ARNs to be assigned to the ALB listener."
+  type        = set(string)
+}
+
 variable "aws_region" {
   default     = "us-east-1"
   description = "The AWS region name in which the main infrastructure should be deployed."


### PR DESCRIPTION
This feature allows the assignment of additional certificate ARNs to the HTTPS ALB listener. The purpose of this is to support HTTPS for DNS configurations outside of the included infrastructure.

For example, the plan for the `production` environment is to deploy it to `prod.aws-ecs-demo.<domain>.com`, delegate DNS for `<domain>.com` to the created hosted zone, then direct traffic for the user-friendly `aws-ecs-demo.<domain>.com` via a CNAME to `prod.aws-ecs-demo.<domain>.com`.